### PR TITLE
allow user defined render option defaults.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pytket-offline-display",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "pytket-offline-display",
   "description": "## Circuit renderer component from within pytket.",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "scripts": {
     "build": "webpack",

--- a/pytket/extensions/offline_display/__init__.py
+++ b/pytket/extensions/offline_display/__init__.py
@@ -45,9 +45,14 @@ env = Environment(
     loader=loader, extensions=[IncludeRawExtension]
 )
 
-# Expose the rendering methods with the local jinja env.
-circuit_renderer = CircuitRenderer(env)
 
-render_circuit_as_html = circuit_renderer.render_circuit_as_html
-render_circuit_jupyter = circuit_renderer.render_circuit_jupyter
-view_browser = circuit_renderer.view_browser
+def get_circuit_renderer():
+    """Get a configurable instance of the circuit renderer."""
+    return CircuitRenderer(env)
+
+
+# Expose the rendering methods with the local jinja env.
+_default_circuit_renderer = get_circuit_renderer()
+render_circuit_as_html = _default_circuit_renderer.render_circuit_as_html
+render_circuit_jupyter = _default_circuit_renderer.render_circuit_jupyter
+view_browser = _default_circuit_renderer.view_browser

--- a/pytket/extensions/offline_display/js/index.js
+++ b/pytket/extensions/offline_display/js/index.js
@@ -8,9 +8,14 @@ function displayCircuit () {
   const app = createApp({
     delimiters: ['[[#', '#]]'],
     components: { CircuitDisplayContainer },
+    data () {
+      return {
+        initRenderOptions: displayOptions, // inserted by jinja in parent
+      }
+    }
   })
   app.config.unwrapInjectedRef = true
-  app.mount('#circuit-display-vue-container-'+circuitRendererUid)
+  app.mount('#circuit-display-vue-container-'+circuitRendererUid)  // inserted by jinja
   return app
 }
 

--- a/readme.md
+++ b/readme.md
@@ -20,3 +20,15 @@ circ.measure_all()
 
 render_circuit_jupyter(circ)
 ```
+
+If you want to control the default options, you can instead load a configurable instance.
+(Note that this requires pytket >= 1.15)
+```python
+from pytket.extensions.offline_display import get_circuit_renderer
+
+circuit_renderer = get_circuit_renderer()
+circuit_renderer.set_display_options(zx_style=False)  # set the default options.
+circuit_renderer.dark_mode = True  # You can also set them directly.
+
+circuit_renderer.render_circuit_jupyter(circ)
+```

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=setuptools.find_namespace_packages(),
     install_requires=[
         "jinja2 ~= 3.0",
-        "pytket > 1.11.1",
+        "pytket >= 1.15.0",
     ],
     cmdclass={
         "build_py": NPMBuild,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     author="TKET development team",
     author_email="tket-support@cambridgequantum.com",
     python_requires=">=3.9",
-    version="0.0.4",
+    version="0.0.5",
     project_urls={
         "Documentation": "https://cqcl.github.io/tket/pytket/api/index.html",
         "Source": "https://github.com/CQCL/pytket-offline-renderer",


### PR DESCRIPTION
Update render option customisation to match pytket.display.
Note that this isn't backwards compatible with older pytket versions.