### PR TITLE
Update circuit renderer v0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "pytket-offline-display",
-  "version": "0.0.5",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pytket-offline-display",
-      "version": "0.0.5",
+      "version": "0.0.8",
       "license": "APACHE 2",
       "dependencies": {
-        "pytket-circuit-renderer": "^0.7",
+        "pytket-circuit-renderer": "^0.9.0",
         "vue": "^3.2.45"
       },
       "devDependencies": {
@@ -1262,9 +1262,9 @@
       }
     },
     "node_modules/pytket-circuit-renderer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/pytket-circuit-renderer/-/pytket-circuit-renderer-0.7.0.tgz",
-      "integrity": "sha512-SZRhcELUNRiJtIGtlQSlZCPOPkOTn1Sw+zPNTX+vlWL3A4ScxOeAR/UKL1W6iLXAxqYzzui9PZ6oPZo14Iuu/A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/pytket-circuit-renderer/-/pytket-circuit-renderer-0.9.0.tgz",
+      "integrity": "sha512-TCmbViLMzY9NZjgZkPxeh4zbMgZ0BR87fopF7flvdNq7QbAEhF8nXtYDf9hkpa3lAmr9R/2rZKd4ClJTzL7l8g==",
       "dependencies": {
         "dom-to-image": "^2.6.0",
         "mathjs": "^11.6.0",
@@ -2779,9 +2779,9 @@
       "dev": true
     },
     "pytket-circuit-renderer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/pytket-circuit-renderer/-/pytket-circuit-renderer-0.7.0.tgz",
-      "integrity": "sha512-SZRhcELUNRiJtIGtlQSlZCPOPkOTn1Sw+zPNTX+vlWL3A4ScxOeAR/UKL1W6iLXAxqYzzui9PZ6oPZo14Iuu/A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/pytket-circuit-renderer/-/pytket-circuit-renderer-0.9.0.tgz",
+      "integrity": "sha512-TCmbViLMzY9NZjgZkPxeh4zbMgZ0BR87fopF7flvdNq7QbAEhF8nXtYDf9hkpa3lAmr9R/2rZKd4ClJTzL7l8g==",
       "requires": {
         "dom-to-image": "^2.6.0",
         "mathjs": "^11.6.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
-    "pytket-circuit-renderer": "^0.7",
+    "pytket-circuit-renderer": "^0.9.0",
     "vue": "^3.2.45"
   },
   "name": "pytket-offline-display",
   "description": "## Circuit renderer component from within pytket.",
-  "version": "0.0.5",
+  "version": "0.0.8",
   "private": true,
   "scripts": {
     "build": "webpack",

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ If you want to control the default options, you can instead load a configurable 
 from pytket.extensions.offline_display import get_circuit_renderer
 
 circuit_renderer = get_circuit_renderer()
-circuit_renderer.set_display_options(zx_style=False)  # set the default options.
+circuit_renderer.set_render_options(zx_style=False)  # set the default options.
 circuit_renderer.dark_mode = True  # You can also set them directly.
 
 circuit_renderer.render_circuit_jupyter(circ)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     author="TKET development team",
     author_email="tket-support@cambridgequantum.com",
     python_requires=">=3.9",
-    version="0.0.6",
+    version="0.0.8",
     project_urls={
         "Documentation": "https://cqcl.github.io/tket/pytket/api/index.html",
         "Source": "https://github.com/CQCL/pytket-offline-renderer",


### PR DESCRIPTION
update to latest circuit renderer version
also fix typo in readme (https://github.com/CQCL/pytket-offline-renderer/issues/7)